### PR TITLE
Choose between name or id. Don't fail if no networks attached.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Required variables:
 - `idr_instance_network_networks`: A list of networks the server should be connected to.
   If the instance is connected to other networks which aren't in this list they *won't* be removed from the server.
 
+Optional variables:
+- `idr_instance_networks_server_key`: Whether to lookup servers by name or id, default `name`
+
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Required variables:
   If the instance is connected to other networks which aren't in this list they *won't* be removed from the server.
 
 Optional variables:
-- `idr_instance_networks_server_key`: Whether to lookup servers by name or id, default `name`
+- `idr_instance_network_server_key`: Whether to lookup servers by name or id, default `name`
 
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for roles/openstack-idr-instance-networks
 
-idr_instance_networks_server_key: name
+idr_instance_network_server_key: name

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for roles/openstack-idr-instance-networks
+
+idr_instance_networks_server_key: name

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,14 +9,25 @@
   os_networks_facts:
   always_run: yes
 
-- debug:
-    msg: >
-      {{ (openstack_servers |
-           selectattr("name", "equalto", idr_instance_network_server) | list)
-           .0.networks }}
+- name: idr vm | debug server
+  debug:
+    msg: "{{ idr_instance_network_server }}"
     verbosity: 1
 
-- debug:
+- name: idr vm | debug server networks
+  debug:
+    msg: >
+      {{
+        (openstack_servers |
+          selectattr(idr_instance_networks_server_key, "equalto", idr_instance_network_server) |
+          first |
+          default( {'networks': []} ))
+        .networks
+      }}
+    verbosity: 1
+
+- name: idr vm | debug required networks
+  debug:
     msg: >
       {{ (openstack_networks | selectattr("name", "equalto", item) | list)
       }}
@@ -31,7 +42,12 @@
         selectattr("name", "equalto", item) | list).0.id }}
       {{ idr_instance_network_server }}
   when: >
-    item not in ((openstack_servers |
-      selectattr("name", "equalto", idr_instance_network_server) | list).0.networks)
+    item not in (
+      (openstack_servers |
+        selectattr(idr_instance_networks_server_key, "equalto", idr_instance_network_server) |
+        first |
+        default( {'networks': []} ))
+      .networks
+    )
   with_items:
   - "{{ idr_instance_network_networks }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     msg: >
       {{
         (openstack_servers |
-          selectattr(idr_instance_networks_server_key, "equalto", idr_instance_network_server) |
+          selectattr(idr_instance_network_server_key, "equalto", idr_instance_network_server) |
           first |
           default( {'networks': []} ))
         .networks
@@ -44,7 +44,7 @@
   when: >
     item not in (
       (openstack_servers |
-        selectattr(idr_instance_networks_server_key, "equalto", idr_instance_network_server) |
+        selectattr(idr_instance_network_server_key, "equalto", idr_instance_network_server) |
         first |
         default( {'networks': []} ))
       .networks


### PR DESCRIPTION
Sometimes servers are referred to by ID instead of name (particularly when obtaining a list of servers automatically). This adds a variable `idr_instance_networks_server_key` to let you indicate that server `id` will be used instead of the default `name`.

This also includes a bug fix for the case where an instance has no networks attached, the previous code assumed there was always at least one leading to an indexing error.

Suggested tag: 1.1.0